### PR TITLE
Add support for ignore case

### DIFF
--- a/lib/reso_api/app/models/reso/api/client.rb
+++ b/lib/reso_api/app/models/reso/api/client.rb
@@ -75,6 +75,7 @@ module RESO
             "$expand": hash[:expand],
             "$count": hash[:count].to_s.presence,
             "$ignorenulls": hash[:ignorenulls].to_s.presence,
+            "$ignorecase": hash[:ignorecase].to_s.presence,
             "$debug": hash[:debug]
           }.compact
           if !block.nil?


### PR DESCRIPTION
This PR allows for support of case-insensitive searches which is supported at CS1.

`client.members(expand: "Office", filter: "MemberFirstName eq '#{first_name}' and MemberLastName eq '#{last_name}') and OriginatingSystemName eq '#{@mls.originating_system_name}'", ignorecase: true)
   `